### PR TITLE
Fixes #11:  add reporter to fillExtraTables

### DIFF
--- a/jsmiparser-api/src/main/java/org/jsmiparser/exception/SmiMultipleValueException.java
+++ b/jsmiparser-api/src/main/java/org/jsmiparser/exception/SmiMultipleValueException.java
@@ -1,0 +1,22 @@
+package org.jsmiparser.exception;
+
+import org.jsmiparser.smi.SmiOidValue ;
+
+public class SmiMultipleValueException extends IllegalArgumentException {
+	private final SmiOidValue m_value1  ;
+	private final SmiOidValue m_value2  ;
+	
+	public SmiMultipleValueException(SmiOidValue value1, SmiOidValue value2) {
+		super("more than one found (" + value1 + " and " + value2 + ")") ;
+		this.m_value1 = value1 ;
+		this.m_value2 = value2 ;
+	}
+	
+	public SmiOidValue getValue1() {
+		return m_value1 ;
+	}
+	
+	public SmiOidValue getValue2() {
+		return m_value2 ;
+	}
+}

--- a/jsmiparser-api/src/main/java/org/jsmiparser/phase/xref/XRefPhase.java
+++ b/jsmiparser-api/src/main/java/org/jsmiparser/phase/xref/XRefPhase.java
@@ -98,7 +98,7 @@ public class XRefPhase implements Phase {
         Collection<SmiModule> modules = mib.getModules();
         resolveReferences(modules);
         resolveOids(modules);
-        mib.fillExtraTables();
+        mib.fillExtraTables(m_reporter);
         resolveDefaultValues(mib);
 
         return mib;

--- a/jsmiparser-api/src/main/java/org/jsmiparser/phase/xref/XRefProblemReporter.java
+++ b/jsmiparser-api/src/main/java/org/jsmiparser/phase/xref/XRefProblemReporter.java
@@ -68,4 +68,7 @@ public interface XRefProblemReporter {
 
     @ProblemMethod(message = "Couldn't resolve non-last subid %s")
     void reportCannotResolveNonLastSubid(Token token);
+    
+    @ProblemMethod(message = "More than one value found (%s and %s)", severity = ProblemSeverity.WARNING)
+    void reportMoreThanOneValue(IdToken token1, IdToken token2);
 }

--- a/jsmiparser-api/src/main/java/org/jsmiparser/smi/SmiMib.java
+++ b/jsmiparser-api/src/main/java/org/jsmiparser/smi/SmiMib.java
@@ -153,10 +153,10 @@ public class SmiMib {
         }
     }
 
-    public void fillExtraTables() {
+    public void fillExtraTables(XRefProblemReporter reporter) {
         // TODO deal with double defines
         for (SmiModule module : m_moduleMap.values()) {
-            module.fillExtraTables();
+            module.fillExtraTables(reporter);
             m_scalarMap.putAll(module.m_scalarMap);
             m_columnMap.putAll(module.m_columnMap);
         }

--- a/jsmiparser-api/src/main/java/org/jsmiparser/smi/SmiModule.java
+++ b/jsmiparser-api/src/main/java/org/jsmiparser/smi/SmiModule.java
@@ -15,6 +15,7 @@
  */
 package org.jsmiparser.smi;
 
+import org.jsmiparser.exception.SmiMultipleValueException ;
 import org.jsmiparser.phase.xref.XRefProblemReporter;
 import org.jsmiparser.util.token.IdToken;
 import org.slf4j.Logger;
@@ -308,12 +309,16 @@ public class SmiModule {
         }
     }
 
-    public void fillExtraTables() {
+    public void fillExtraTables(XRefProblemReporter reporter) {
         for (SmiVariable variable : m_variableMap.values()) {
-            if (variable.isColumn()) {
-                m_columnMap.put(variable.getId(), variable);
-            } else {
-                m_scalarMap.put(variable.getId(), variable);
+            try {
+                if (variable.isColumn()) {
+                    m_columnMap.put(variable.getId(), variable);
+                } else {
+                    m_scalarMap.put(variable.getId(), variable);
+                }
+            } catch (SmiMultipleValueException e) {
+            	reporter.reportMoreThanOneValue(e.getValue1().getIdToken(), e.getValue2().getIdToken()) ;
             }
         }
     }

--- a/jsmiparser-api/src/main/java/org/jsmiparser/smi/SmiOidNode.java
+++ b/jsmiparser-api/src/main/java/org/jsmiparser/smi/SmiOidNode.java
@@ -1,5 +1,7 @@
 package org.jsmiparser.smi;
 
+import org.jsmiparser.exception.SmiMultipleValueException ;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -129,7 +131,7 @@ public class SmiOidNode {
                 if (result == null) {
                     result = clazz.cast(value);
                 } else {
-                    throw new IllegalArgumentException("more than one found");
+                    throw new SmiMultipleValueException(result, value);
                 }
             }
         }


### PR DESCRIPTION
With these changes, a proper parse report-event will be returned when parsing two different tables with the same OID (instead of exception).

```
Warning: file://null :More than one value found (file:///home/workspace/mib-parser/mibs/issue-11/VENDOR-MIB.mib:3252:9:xxxProcessingCountersAllowedEntry and file:///home/workspace/mib-parser/mibs/issue-11/VENDOR-MIB.mib:3313:9:xxxProcessingCountersBlockedEntry)
...
```

> **Note** Severity is set to warning as to allow parser to progress further while both tables are not 'filled'